### PR TITLE
Modify git commands in sync-repo.sh

### DIFF
--- a/sync-repo.sh
+++ b/sync-repo.sh
@@ -1,20 +1,13 @@
 # This bash script uses git to synchronize changes between the local and remote GitHub repository.
 # TODO: Ask copilot chat to review the script and suggest improvements.
 
-git add .
+git stage .
 
 git commit -m "Updated"
 
 git pull origin main
 
-git push 
-
-# Check if the push was successful
-if [ $? -eq 0 ]; then
-    echo "Changes pushed successfully to the remote repository."
-else
-    echo "Failed to push changes to the remote repository. Please check for conflicts or errors."
-fi
+git push origin main
 
 
 


### PR DESCRIPTION
This pull request makes a small update to the `sync-repo.sh` script, changing the way files are staged and simplifying the push process.

* Changed the staging command from `git add .` to `git stage .` for adding files to the staging area.
* Simplified the push command by removing the success/failure check and always pushing to `origin main`.